### PR TITLE
User-defined operators

### DIFF
--- a/src/consts/ops.es6
+++ b/src/consts/ops.es6
@@ -4,6 +4,9 @@
  * UOP - Unary operators
 **/
 
+export const UD_OP = new Set();
+export const UD_UOP = new Set();
+
 export const RESERVED_KEYWORDS = new Set([
     'sqrt', 'cbrt', 'root',
     'sin', 'cos', 'tan',

--- a/src/states/op.es6
+++ b/src/states/op.es6
@@ -1,0 +1,30 @@
+import CheddarLexer from '../tok/lex';
+import CheddarVariableToken from '../literals/var';
+
+import { OP, UOP } from '../consts/ops';
+
+export default class StatementOp extends CheddarLexer {
+    exec() {
+        this.open(false);
+
+        let res = this.grammar(true,
+            [
+                ['binary', 'unary'], this.jumpWhite, 'op', this.jumpWhite, CheddarVariableToken
+            ]
+        );
+
+        if (res instanceof CheddarLexer) {
+            let modifier = res._Tokens[0];
+            let operator = res._Tokens[1]._Tokens[0];
+
+            if (modifier === 'unary') {
+                UOP.push(operator);
+            } else if (modifier === 'binary') {
+                OP.push(operator);
+            }
+
+        }
+
+        return res;
+    }
+}

--- a/src/tok.es6
+++ b/src/tok.es6
@@ -14,7 +14,8 @@ import S2_IF from './states/if';
 import S2_FOR from './states/for';
 import S3_FUNC from './states/func';
 import S4_CLASS from './states/class';
-import S5_EXPR from './states/expr';
+import S5_OP from './states/op';
+import S6_EXPR from './states/expr';
 
 var CLOSES = '\n;';
 
@@ -38,7 +39,8 @@ export default class CheddarTokenize extends CheddarLexer {
             S2_FOR,
             S3_FUNC,
             S4_CLASS,
-            S5_EXPR
+            S5_OP,
+            S6_EXPR
         ]), {
             tok: this.constructor,
             args: { ENDS, PARSERS }


### PR DESCRIPTION
Syntax:

```
unary op foo
foo 1
```

```
binary op foo
1 foo 2
```
